### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/iam.tf
+++ b/src/iam.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "github_action_runner" {
     sid     = "AllowGetGitHubToken"
     actions = ["ssm:GetParameters"]
     resources = [
-      join("", data.aws_ssm_parameter.github_token.*.arn)
+      join("", data.aws_ssm_parameter.github_token[*].arn)
     ]
   }
 }
@@ -96,7 +96,7 @@ resource "aws_iam_role" "github_action_runner" {
   name                = module.this.id
   tags                = module.this.tags
   assume_role_policy  = data.aws_iam_policy_document.instance_assume_role_policy[0].json
-  managed_policy_arns = concat([join("", aws_iam_policy.github_action_runner.*.arn), "arn:${local.aws_partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.runner_role_additional_policy_arns)
+  managed_policy_arns = concat([join("", aws_iam_policy.github_action_runner[*].arn), "arn:${local.aws_partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"], var.runner_role_additional_policy_arns)
 }
 
 resource "aws_iam_instance_profile" "github_action_runner" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -20,7 +20,7 @@ locals {
       encoding    = "b64"
       content = base64encode(templatefile(local.deregister_runner_script_template, {
         github_scope          = var.github_scope,
-        github_token_ssm_path = join("", data.aws_ssm_parameter.github_token.*.name),
+        github_token_ssm_path = join("", data.aws_ssm_parameter.github_token[*].name),
         runner_version        = var.runner_version
       }))
     },
@@ -67,7 +67,7 @@ data "cloudinit_config" "config" {
     filename     = "user-data.sh"
     content = templatefile(local.userdata_template, {
       docker_compose_version = var.docker_compose_version
-      github_token_ssm_path  = join("", data.aws_ssm_parameter.github_token.*.name)
+      github_token_ssm_path  = join("", data.aws_ssm_parameter.github_token[*].name)
       github_scope           = var.github_scope
       labels                 = join(",", var.runner_labels)
       pre_install            = var.userdata_pre_install
@@ -109,7 +109,7 @@ module "autoscale_group" {
   source  = "cloudposse/ec2-autoscale-group/aws"
   version = "0.43.1"
 
-  image_id                    = join("", data.aws_ami.runner.*.id)
+  image_id                    = join("", data.aws_ami.runner[*].id)
   instance_type               = var.instance_type
   mixed_instances_policy      = var.mixed_instances_policy
   subnet_ids                  = local.vpc_private_subnet_ids
@@ -119,10 +119,10 @@ module "autoscale_group" {
   default_cooldown            = var.default_cooldown
   scale_down_cooldown_seconds = var.scale_down_cooldown_seconds
   wait_for_capacity_timeout   = var.wait_for_capacity_timeout
-  user_data_base64            = join("", data.cloudinit_config.config.*.rendered)
+  user_data_base64            = join("", data.cloudinit_config.config[*].rendered)
   tags                        = module.this.tags
   security_group_ids          = [module.sg.id]
-  iam_instance_profile_name   = join("", aws_iam_instance_profile.github_action_runner.*.name)
+  iam_instance_profile_name   = join("", aws_iam_instance_profile.github_action_runner[*].name)
   block_device_mappings       = var.block_device_mappings
   associate_public_ip_address = false
   max_instance_lifetime       = var.max_instance_lifetime

--- a/src/modules/graceful_scale_in/eventbridge.tf
+++ b/src/modules/graceful_scale_in/eventbridge.tf
@@ -1,5 +1,5 @@
 locals {
-  automation_definition_arn = "arn:${join("", data.aws_partition.current.*.partition)}:ssm:${join("", data.aws_region.current.*.name)}:${join("", data.aws_caller_identity.current.*.account_id)}:automation-definition/${join("", aws_ssm_document.default.*.name)}:$DEFAULT"
+  automation_definition_arn = "arn:${join("", data.aws_partition.current[*].partition)}:ssm:${join("", data.aws_region.current[*].name)}:${join("", data.aws_caller_identity.current[*].account_id)}:automation-definition/${join("", aws_ssm_document.default[*].name)}:$DEFAULT"
 }
 
 module "eventbridge_label" {
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "eventbridge_policy" {
       "iam:PassRole"
     ]
     resources = [
-      join("", aws_iam_role.ssm_document_role.*.arn)
+      join("", aws_iam_role.ssm_document_role[*].arn)
     ]
   }
 }
@@ -51,7 +51,7 @@ resource "aws_iam_policy" "eventbridge_policy" {
 
   name   = module.eventbridge_label.id
   tags   = module.eventbridge_label.tags
-  policy = join("", data.aws_iam_policy_document.eventbridge_policy.*.json)
+  policy = join("", data.aws_iam_policy_document.eventbridge_policy[*].json)
 }
 
 resource "aws_iam_role" "eventbridge_role" {
@@ -59,8 +59,8 @@ resource "aws_iam_role" "eventbridge_role" {
 
   name                = module.eventbridge_label.id
   tags                = module.eventbridge_label.tags
-  assume_role_policy  = join("", data.aws_iam_policy_document.eventbridge_assume_role_policy.*.json)
-  managed_policy_arns = [join("", aws_iam_policy.eventbridge_policy.*.arn)]
+  assume_role_policy  = join("", data.aws_iam_policy_document.eventbridge_assume_role_policy[*].json)
+  managed_policy_arns = [join("", aws_iam_policy.eventbridge_policy[*].arn)]
 }
 
 resource "aws_cloudwatch_event_rule" "default" {
@@ -88,10 +88,10 @@ resource "aws_cloudwatch_event_rule" "default" {
 resource "aws_cloudwatch_event_target" "default" {
   count = local.enabled ? 1 : 0
 
-  rule      = join("", aws_cloudwatch_event_rule.default.*.name)
+  rule      = join("", aws_cloudwatch_event_rule.default[*].name)
   target_id = module.this.id
   arn       = local.automation_definition_arn
-  role_arn  = join("", aws_iam_role.eventbridge_role.*.arn)
+  role_arn  = join("", aws_iam_role.eventbridge_role[*].arn)
   input_transformer {
     input_paths = {
       "asgname" : "$.detail.AutoScalingGroupName",
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_event_target" "default" {
         <lchname>
       ],
       "automationAssumeRole": [
-        "${join("", aws_iam_role.ssm_document_role.*.arn)}"
+        "${join("", aws_iam_role.ssm_document_role[*].arn)}"
       ]
     }
     EOF

--- a/src/modules/graceful_scale_in/outputs.tf
+++ b/src/modules/graceful_scale_in/outputs.tf
@@ -1,19 +1,19 @@
 output "eventbridge_rule_arn" {
   description = "The ARN of the Eventbridge rule for the EC2 lifecycle transition."
-  value       = join("", aws_cloudwatch_event_rule.default.*.arn)
+  value       = join("", aws_cloudwatch_event_rule.default[*].arn)
 }
 
 output "eventbridge_target_arn" {
   description = "The ARN of the Eventbridge target corresponding to the Eventbridge rule for the EC2 lifecycle transition."
-  value       = join("", aws_cloudwatch_event_target.default.*.arn)
+  value       = join("", aws_cloudwatch_event_target.default[*].arn)
 }
 
 output "autoscaling_lifecycle_hook_name" {
   description = "The name of the Lifecycle Hook for the Auto Scaling Group."
-  value       = join("", aws_autoscaling_lifecycle_hook.default.*.name)
+  value       = join("", aws_autoscaling_lifecycle_hook.default[*].name)
 }
 
 output "ssm_document_arn" {
   description = "The ARN of the SSM document."
-  value       = join("", aws_ssm_document.default.*.arn)
+  value       = join("", aws_ssm_document.default[*].arn)
 }

--- a/src/modules/graceful_scale_in/ssm.tf
+++ b/src/modules/graceful_scale_in/ssm.tf
@@ -1,6 +1,6 @@
 locals {
   # The CompleteLifeCycle Action requires a wildcard in the Auto Scaling Group ARN, so we cannot reference the aws_autoscaling_group data source directly
-  asg_wildcard_arn = "arn:${join("", data.aws_partition.current.*.partition)}:autoscaling:${join("", data.aws_region.current.*.name)}:${join("", data.aws_caller_identity.current.*.account_id)}:autoScalingGroup:*:autoScalingGroupName/${join("", data.aws_autoscaling_group.default.*.name)}"
+  asg_wildcard_arn = "arn:${join("", data.aws_partition.current[*].partition)}:autoscaling:${join("", data.aws_region.current[*].name)}:${join("", data.aws_caller_identity.current[*].account_id)}:autoScalingGroup:*:autoScalingGroupName/${join("", data.aws_autoscaling_group.default[*].name)}"
 }
 
 module "ssm_document_label" {
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "ssm_document_policy" {
     sid     = "AllowSendSSMCommandShellScript"
     actions = ["ssm:SendCommand"]
     resources = [
-      "arn:${join("", data.aws_partition.current.*.partition)}:ssm:${join("", data.aws_region.current.*.name)}::document/AWS-RunShellScript"
+      "arn:${join("", data.aws_partition.current[*].partition)}:ssm:${join("", data.aws_region.current[*].name)}::document/AWS-RunShellScript"
     ]
   }
 
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "ssm_document_policy" {
     sid     = "AllowSendSSMCommandInstances"
     actions = ["ssm:SendCommand"]
     resources = [
-      "arn:${join("", data.aws_partition.current.*.partition)}:ec2:*:*:instance/*"
+      "arn:${join("", data.aws_partition.current[*].partition)}:ec2:*:*:instance/*"
     ]
   }
 }
@@ -73,7 +73,7 @@ resource "aws_iam_policy" "ssm_document_policy" {
   count = local.enabled ? 1 : 0
 
   name   = module.ssm_document_label.id
-  policy = join("", data.aws_iam_policy_document.ssm_document_policy.*.json)
+  policy = join("", data.aws_iam_policy_document.ssm_document_policy[*].json)
 
   tags = module.ssm_document_label.tags
 }
@@ -83,6 +83,6 @@ resource "aws_iam_role" "ssm_document_role" {
 
   name                = module.ssm_document_label.id
   tags                = module.ssm_document_label.tags
-  assume_role_policy  = join("", data.aws_iam_policy_document.ssm_document_assume_role_policy.*.json)
-  managed_policy_arns = [join("", aws_iam_policy.ssm_document_policy.*.arn)]
+  assume_role_policy  = join("", data.aws_iam_policy_document.ssm_document_assume_role_policy[*].json)
+  managed_policy_arns = [join("", aws_iam_policy.ssm_document_policy[*].arn)]
 }


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)